### PR TITLE
metadata: use provides for image-service relation

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -37,10 +37,12 @@ requires:
     limit: 1
   amqp:
     interface: rabbitmq
-  image-service:
-    interface: glance
   ceph:
     interface: ceph-client
+
+provides:
+  image-service:
+    interface: glance
 
 peers:
   peers:


### PR DESCRIPTION
The Glance Image Service is in use by the OpenStack data plane.

With the move to keeping the OpenStack control plane in a
Kubernetes model we may end up putting data plane components such
as nova-compute in a machine model and use Cross Model Relations
between the two.

When attempting to consume the image-service relation from CMR
currently you would get a error message like this from Juju:

    $ juju consume admin/openstack-control.image-serviceAdded \
        admin/openstack-control.image-service as image-service
    $ juju add-relation nova-compute image-service
    ERROR no relations found

Switching the Glance charm to offer the image-service relation on
the provides side of a relation will resolve this situation.